### PR TITLE
Update release-cycle.json URL

### DIFF
--- a/pre_commit_python_eol/bump_cache.py
+++ b/pre_commit_python_eol/bump_cache.py
@@ -17,9 +17,7 @@ USER_AGENT = (
     f"{platform.python_implementation()}/{platform.python_version()}"
 )
 
-CACHE_SOURCE = (
-    "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
-)
+CACHE_SOURCE = "https://peps.python.org/api/release-cycle.json"
 LOCAL_CACHE = Path("./cached_release_cycle.json")
 
 

--- a/pre_commit_python_eol/check_eol.py
+++ b/pre_commit_python_eol/check_eol.py
@@ -72,8 +72,8 @@ class PythonRelease:  # noqa: D101
         """
         Create a `PythonRelease` instance from the provided JSON components.
 
-        JSON components are assumed to be of the format provided by the Python Devguide:
-        https://github.com/python/devguide/blob/main/include/release-cycle.json
+        JSON components are assumed to be of the format provided by the Python PEPs API:
+        https://peps.python.org/api/release-cycle.json
         """
         return cls(
             python_ver=version.Version(ver),


### PR DESCRIPTION
This file is now generated and published from the PEPs repo (https://github.com/python/peps/pull/4331) and will be removed from the devguide soon (https://github.com/python/devguide/pull/1685).
